### PR TITLE
Use dumpdata and natural keys

### DIFF
--- a/smuggler/utils.py
+++ b/smuggler/utils.py
@@ -9,17 +9,8 @@
 import os
 from django.core.exceptions import PermissionDenied
 from django.core.management.commands.dumpdata import Command as DumpData
-from django.db.models import get_model
 from django.http import HttpResponse
-from smuggler.settings import (SMUGGLER_EXCLUDE_LIST, SMUGGLER_FORMAT,
-                               SMUGGLER_INDENT)
-
-def get_excluded_models_set():
-    excluded_models = set([])
-    for label in SMUGGLER_EXCLUDE_LIST:
-        app_label, model_label = label.split('.')
-        excluded_models.add(get_model(app_label, model_label))
-    return excluded_models
+from smuggler.settings import (SMUGGLER_FORMAT, SMUGGLER_INDENT)
 
 def get_file_list(path):
     file_list = []

--- a/smuggler/views.py
+++ b/smuggler/views.py
@@ -9,7 +9,6 @@
 import os
 from datetime import datetime
 from django.core import serializers
-from django.db.models import get_app, get_apps, get_model, get_models
 from django.shortcuts import render_to_response
 from django.template import RequestContext
 from django.utils.translation import ugettext as _
@@ -18,7 +17,7 @@ from django.contrib import messages
 from smuggler.forms import ImportFileForm
 from smuggler.settings import (SMUGGLER_FORMAT, SMUGGLER_FIXTURE_DIR,
                                SMUGGLER_EXCLUDE_LIST)
-from smuggler.utils import (get_excluded_models_set, get_file_list,
+from smuggler.utils import (get_file_list,
                             save_uploaded_file_on_disk, serialize_to_response,
                             superuser_required)
 


### PR DESCRIPTION
Django's dumpdata command does some extra things to make sure the objects are sorted in a way they can be imported reliably. By reusing the dumpdata command django-smuggler can do the same.

This pull requests also includes (a modified version of) the dry_views branch.
