### PR TITLE
Some misc dev cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 ._*
 .#*
 *#
+.tox/
 build/
 dist/
 django_smuggler.egg-info/

--- a/README.rst
+++ b/README.rst
@@ -196,6 +196,21 @@ Thanks to `Interaction Consortium <http://interactionconsortium.com/>`_ for
 sponsoring the first releases of the project.
 
 
+Tests
+=====
+
+You can run tests with your current version of python and django with::
+
+    cd /path/to/django-smuggler
+    python tests/run_tests.py
+
+We use `tox <https://pypi.python.org/pypi/tox>` to test against multiple 
+versions of python and django. Please run::
+
+    cd /path/to/django-smuggler
+    tox
+
+
 Copying conditions
 ==================
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,21 +1,10 @@
 [tox]
-envlist    = py25-1.2, py25-1.3,
-             py26-1.3, py26-1.4, py26-1.5,
+envlist    = py26-1.3, py26-1.4, py26-1.5,
              py27-1.3, py27-1.4, py27-1.5
 
 [testenv]
 commands   = python tests/run_tests.py
 deps       = unittest2
-
-[testenv:py25-1.2]
-basepython = python2.5
-deps       = django>=1.2,<1.3
-            {[testenv]deps}
-
-[testenv:py25-1.3]
-basepython = python2.5
-deps       = django>=1.3,<1.4
-            {[testenv]deps}
 
 [testenv:py26-1.3]
 basepython = python2.6


### PR DESCRIPTION
@semente @jaap3

Just some minor things here:
- Documentation and gitignore.
- I removed the tox tests for python 2.5 because they are no longer supported.  Proof below:

```
(smuggler)[peterconerly@django-smuggler]$ tox
GLOB sdist-make: /Users/peterconerly/code/django-smuggler/setup.py
py25-1.2 create: /Users/peterconerly/code/django-smuggler/.tox/py25-1.2
ERROR: UnsupportedInterpreter: python2.5 is not supported anymore, sorry
py25-1.3 create: /Users/peterconerly/code/django-smuggler/.tox/py25-1.3
ERROR: UnsupportedInterpreter: python2.5 is not supported anymore, sorry
```
