### PR TITLE
Django 1.7 and use_natural_keys

### DIFF
--- a/smuggler/utils.py
+++ b/smuggler/utils.py
@@ -43,6 +43,7 @@ def serialize_to_response(app_labels=[], exclude=[], response=None,
             'exclude': exclude,
             'format': format,
             'indent': indent,
+            'use_natural_keys': True,
             'use_natural_foreign_keys': True,
             'use_natural_primary_keys': True
         })

--- a/smuggler/utils.py
+++ b/smuggler/utils.py
@@ -43,7 +43,8 @@ def serialize_to_response(app_labels=[], exclude=[], response=None,
             'exclude': exclude,
             'format': format,
             'indent': indent,
-            'use_natural_keys': True
+            'use_natural_foreign_keys': True,
+            'use_natural_primary_keys': True
         })
     except SystemExit:
         # Django 1.4's implementation of execute catches CommandErrors and


### PR DESCRIPTION
`use_natural_keys ` option deprecated in Django 1.7, so we can use `use_natural_foreign_keys` and `use_natural_primary_keys` (issue #48)