### PR TITLE
Update to suport Django 1.10

### DIFF
--- a/smuggler/utils.py
+++ b/smuggler/utils.py
@@ -5,16 +5,16 @@
 # Django Smuggler is free software under terms of the GNU Lesser
 # General Public License version 3 (LGPLv3) as published by the Free
 # Software Foundation. See the file README for copying conditions.
+import django
 from django.core.management.color import no_style
 from django.core.management.commands.dumpdata import Command as DumpData
 from django.core.management.commands.loaddata import Command as LoadData
 from django.core.management import call_command
-
 from django.db.utils import DEFAULT_DB_ALIAS
 from django.http import HttpResponse
 from django.utils.six import StringIO
+
 from smuggler import settings
-import django
 
 
 def save_uploaded_file_on_disk(uploaded_file, destination_path):
@@ -33,7 +33,7 @@ def serialize_to_response(app_labels=None, exclude=None, response=None,
     error_stream = StringIO()
     dumpdata = DumpData()
     dumpdata.style = no_style()
-    args = {
+    kwargs = {
         'stdout': stream,
         'stderr': error_stream,
         'exclude': exclude,
@@ -44,9 +44,9 @@ def serialize_to_response(app_labels=None, exclude=None, response=None,
     }
 
     if django.VERSION[0:2] >= (1, 10):
-        call_command(dumpdata, *app_labels, **args)
+        call_command(dumpdata, *app_labels, **kwargs)
     else:
-        dumpdata.execute(*app_labels, **args)
+        dumpdata.execute(*app_labels, **kwargs)
 
     response.write(stream.getvalue())
     return response
@@ -57,16 +57,17 @@ def load_fixtures(fixtures):
     error_stream = StringIO()
     loaddata = LoadData()
     loaddata.style = no_style()
-    args = {
+    kwargs = {
         'stdout': stream,
         'stderr': error_stream,
         'ignore': True,
         'database': DEFAULT_DB_ALIAS,
         'verbosity': 1
     }
+
     if django.VERSION[0:2] >= (1, 10):
-        call_command(loaddata, *fixtures, **args)
+        call_command(loaddata, *fixtures, **kwargs)
     else:
-        loaddata.execute(*fixtures, **args)
+        loaddata.execute(*fixtures, **kwargs)
 
     return loaddata.loaded_object_count

--- a/smuggler/utils.py
+++ b/smuggler/utils.py
@@ -5,6 +5,7 @@
 # Django Smuggler is free software under terms of the GNU Lesser
 # General Public License version 3 (LGPLv3) as published by the Free
 # Software Foundation. See the file README for copying conditions.
+
 import django
 from django.core.management.color import no_style
 from django.core.management.commands.dumpdata import Command as DumpData

--- a/tests/test_app/tests/test_dump.py
+++ b/tests/test_app/tests/test_dump.py
@@ -1,11 +1,11 @@
 import json
+import django
 from django.utils.six import StringIO
 from django.core.management import CommandError
 from django.test import TestCase
 from tests.test_app.models import Page
+
 from smuggler import utils
-from distutils.version import StrictVersion
-import django
 
 
 class BasicDumpTestCase(TestCase):

--- a/tests/test_app/tests/test_dump.py
+++ b/tests/test_app/tests/test_dump.py
@@ -4,17 +4,22 @@ from django.core.management import CommandError
 from django.test import TestCase
 from tests.test_app.models import Page
 from smuggler import utils
+from distutils.version import StrictVersion
+import django
 
 
 class BasicDumpTestCase(TestCase):
-    SITE_DUMP = [{
-        "pk": 1,
+    SITE_DICT = {
         "model": "sites.site",
         "fields": {
             "domain": "example.com",
             "name": "example.com"
         }
-    }]
+    }
+
+    if django.VERSION[0:2] < (1, 10):
+        SITE_DICT.update({"pk": 1})
+    SITE_DUMP = [SITE_DICT]
     PAGE_DUMP = [{
         "pk": 1,
         "model": "test_app.page",

--- a/tests/test_app/urls.py
+++ b/tests/test_app/urls.py
@@ -2,17 +2,12 @@ from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.conf.urls import url, include
-import django
-from distutils.version import StrictVersion
+
 admin.autodiscover()
 
-extra_url_kwargs = {'prefix': 'admin'} \
-    if StrictVersion(django.get_version()) < StrictVersion('1.7')\
-    else\
-    {}
 urlpatterns = [
     url(r'^admin/', include('smuggler.urls')),
     url(r'^admin/login/$', admin.site.login,
-        name='login', **extra_url_kwargs),  # for Django < 1.7
+        name='login'),  # for Django < 1.7
     url(r'^admin/', include(admin.site.urls))
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)

--- a/tests/test_app/urls.py
+++ b/tests/test_app/urls.py
@@ -2,12 +2,17 @@ from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.conf.urls import url, include
-
+import django
+from distutils.version import StrictVersion
 admin.autodiscover()
 
+extra_url_kwargs = {'prefix': 'admin'} \
+    if StrictVersion(django.get_version()) < StrictVersion('1.7')\
+    else\
+    {}
 urlpatterns = [
     url(r'^admin/', include('smuggler.urls')),
     url(r'^admin/login/$', admin.site.login,
-        name='login', prefix='admin'),  # for Django < 1.7
+        name='login', **extra_url_kwargs),  # for Django < 1.7
     url(r'^admin/', include(admin.site.urls))
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)

--- a/tests/test_app/urls.py
+++ b/tests/test_app/urls.py
@@ -8,6 +8,6 @@ admin.autodiscover()
 urlpatterns = [
     url(r'^admin/', include('smuggler.urls')),
     url(r'^admin/login/$', admin.site.login,
-        name='login'),  # for Django < 1.7
+        name='login'),
     url(r'^admin/', include(admin.site.urls))
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist    = py27-dj17, py34-dj17
              py27-dj18, py34-dj18
              py27-dj19, py34-dj19
+             py27-dj110, py34-dj110
 
 [testenv]
 commands   = python manage.py test
@@ -35,6 +36,16 @@ deps       = Django>=1.9rc2,<1.10
 [testenv:py34-dj19]
 basepython = python3.4
 deps       = Django>=1.9rc2,<1.10
+             {[testenv]deps}
+
+[testenv:py27-dj110]
+basepython = python2.7
+deps       = Django>=1.10<1.11
+             {[testenv]deps}
+
+[testenv:py34-dj110]
+basepython = python3.4
+deps       = Django>=1.10<1.11
              {[testenv]deps}
 
 [testenv:flake8]


### PR DESCRIPTION
Django 1.10 uses natural key for sites, so pk needs to be removed from SITE_DUMP
Using call_command  instead of execute to avoid 'no_color' KeyError
prefix param in url not supported on Django1.10

I usually not do PR, most likely is wrong, but maybe someone can improve it.