### PR TITLE
docs: Fix simple typo, patchs -> patches

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -253,7 +253,7 @@ If you find any problems in the code or documentation, please take 30 seconds
 to fill out a issue `here <https://github.com/semente/django-smuggler/issues>`_.
 
 The contributing with code or translation is MUCH-APPRECIATED. Feel free to
-fork or send patchs.
+fork or send patches.
 
 You can translate this application to your language using Transifex. Access
 the `project page <https://www.transifex.com/projects/p/django-smuggler/.>`_


### PR DESCRIPTION
There is a small typo in README.rst.

Should read `patches` rather than `patchs`.

