### PR TITLE
docs: fix simple typo, compatibilty -> compatibility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -185,7 +185,7 @@ Version 0.7.0 (2016-02-25)
 Version 0.6.1 (2015-11-25)
 --------------------------
 
-* Increase Django 1.7 compatibilty by supporting
+* Increase Django 1.7 compatibility by supporting
   use_natural_foreign_keys and use_natural_primary_keys arguments
   for dumpdata
 


### PR DESCRIPTION
There is a small typo in README.rst.

Should read `compatibility` rather than `compatibilty`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md